### PR TITLE
Feature pytest - corrected typo for the folder tests

### DIFF
--- a/Tests/test_create_season.py
+++ b/Tests/test_create_season.py
@@ -1,7 +1,0 @@
-from BasketIntelligence.create_season import CreateSeason
-
-def test_read_team_adv_stats():
-  
-  dataset = CreateSeason("2025")
-  columns_count = len(dataset.read_stats_per_game().columns)
-  assert columns_count == 28

--- a/tests/test_create_season.py
+++ b/tests/test_create_season.py
@@ -1,0 +1,7 @@
+from BasketIntelligence.create_season import CreateSeason
+
+def test_read_team_adv_stats():
+  
+  dataset = CreateSeason("2025")
+  columns_count = len(dataset.read_stats_per_game().columns)
+  assert columns_count == 28


### PR DESCRIPTION
Typo was the possible reason for pytest error as Tests folder is not seen at the standard path